### PR TITLE
Set moods in utils to match default names from database

### DIFF
--- a/src/Thermometer/Thermometer.js
+++ b/src/Thermometer/Thermometer.js
@@ -17,7 +17,9 @@ function Thermometer() {
     )
       .then(res => res.json())
       .then(response => {
+        console.log(response[0].label)
         setMood(response[0].label)
+       
         // NOTE
         // I can't reach the server because of a CORS error so I can't test this.
         // In production, I 
@@ -41,7 +43,6 @@ function Thermometer() {
   );
 
   function updateMood(mood) {
-
     setMood(mood)
   }
 }

--- a/src/Thermometer/utils.js
+++ b/src/Thermometer/utils.js
@@ -1,1 +1,2 @@
-export const MOODS = ["Very sad", "Sad", "Ok", "Well", "Great"];
+//export const MOODS = ["Very sad", "Sad", "Ok", "Well", "Great"];
+export const MOODS = ["desolate", "dispirited", "sad", "ok", "energized"] 


### PR DESCRIPTION
Kind of pointless PR but just letting you know I tested this and it works. 

The first mood returned from db is 'desolate' so if you change utils.js to match that name (per this PR) it correctly loads data from the api and then shows a sad face on startup. Yay!

<img width="656" alt="image" src="https://user-images.githubusercontent.com/166867/172734785-69fbb279-060e-48c9-b393-19694bb1b5eb.png">
